### PR TITLE
Added install script flag to package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "my-tech-connect-site",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.0",


### PR DESCRIPTION
The package-lock.json file has been updated with a new attribute, "hasInstallScript". This indicates whether the package has an installation script or not.
